### PR TITLE
Remove annoying pull request template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,6 +1,0 @@
-Fixes #[issue]. *Optional*
-
-Changes proposed in this pull request:
-  -
-  -
-  -


### PR DESCRIPTION
Fixes #[issue]. *Optional*

Changes proposed in this pull request:
  - Removes
  - this
  - template

-----

This just makes ugly PR descriptions, especially when people don't remove the `Fixes #[issue]. Optional` or the extra lines of the change list.